### PR TITLE
chore: update Rstack CLI skill

### DIFF
--- a/.agents/skills/rstack-cli-docs/SKILL.md
+++ b/.agents/skills/rstack-cli-docs/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: rstack-cli-best-practices
-description: Guidance for Rstack CLI work involving `rs` commands, `rstack.config.*`, package APIs, or Rstack-based projects and tooling.
+name: rstack-cli-docs
+description: Consult installed, version-matched Rstack docs only for user-facing `rs` command behavior, `rstack.config.*` semantics, or public `rstack` APIs. Do not use for purely internal implementation, tests, performance, or repository maintenance.
 ---
 
-# Rstack CLI Best Practices
+# Rstack CLI Docs
 
 Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one
 config file, and a consistent workflow for the Rstack JavaScript toolchain.
 
 It covers web app, library, docs, test, lint, formatting, Git hook, and staged-file workflows.
 
-## ALWAYS read installed docs before working
+## Read installed docs when this skill applies
 
-Before any Rstack work, find and read the relevant Markdown documentation shipped with the installed `rstack` package.
+When this skill applies, find and read the relevant Markdown documentation shipped with the installed `rstack` package.
 
 Model knowledge can be outdated; the installed documentation is the source of truth for the project's Rstack version.
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,11 +1,12 @@
 {
   "version": 1,
   "skills": {
-    "rstack-cli-best-practices": {
+    "rstack-cli-docs": {
       "source": "rstackjs/rstack-cli",
+      "ref": "main",
       "sourceType": "github",
-      "skillPath": ".agents/skills/rstack-cli-best-practices/SKILL.md",
-      "computedHash": "fa6e3305610cab62c9ec6be3f38a7dfc9917d1417bcd3dc449c46f1ccaec4a2a"
+      "skillPath": ".agents/skills/rstack-cli-docs/SKILL.md",
+      "computedHash": "3bd67c05c2cb4121edd24be65d118e0e7402177bca8a0f1b5bb0ce55dee5e61c"
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR replaces `rstack-cli-best-practices` with the more narrowly scoped `rstack-cli-docs` skill. It limits installed-doc guidance to user-facing `rs` commands, configuration semantics, and public APIs while updating the bundled docs entry path.

## Related Links

- https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/rstack-cli-docs