### PR TITLE
feat: expose resolved skip files to extra tool actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,33 @@ When a local template contains `pnpm-workspace.yaml`, the file is only copied
 if the project is created with pnpm. Templates loaded from third-party npm
 packages are copied without this filtering.
 
+The toolkit automatically passes the resolved `skipFiles` list to custom
+`extraTools` actions. When an action uses `copyFolder` to copy a local tool
+template, forward the received list so the same package-manager filtering is
+applied:
+
+```ts
+import { copyFolder, create } from '@rstackjs/create-toolkit';
+
+create({
+  extraTools: [
+    {
+      value: 'storybook',
+      label: 'Storybook',
+      action: ({ distFolder, skipFiles }) => {
+        copyFolder({
+          from: storybookTemplate,
+          to: distFolder,
+          skipFiles,
+          isMergePackageJson: true,
+        });
+      },
+    },
+  ],
+  // ...other options
+});
+```
+
 ### Git Initialization
 
 By default, the toolkit initializes a Git repository after creating the

--- a/src/index.ts
+++ b/src/index.ts
@@ -933,7 +933,7 @@ export async function create({
           await matchedTool.action({
             templateName,
             distFolder,
-            skipFiles: localSkipFiles,
+            skipFiles: [...localSkipFiles],
             addAgentsMdSearchDirs: (dir: string) =>
               agentsMdSearchDirs.push(dir),
           });

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,6 +464,7 @@ type ExtraTool = {
   action?: (context: {
     templateName: string;
     distFolder: string;
+    skipFiles: string[];
     addAgentsMdSearchDirs: (dir: string) => void;
   }) => unknown;
   /**
@@ -932,6 +933,7 @@ export async function create({
           await matchedTool.action({
             templateName,
             distFolder,
+            skipFiles: localSkipFiles,
             addAgentsMdSearchDirs: (dir: string) =>
               agentsMdSearchDirs.push(dir),
           });

--- a/test/fixtures/package-manager-files/template-storybook/pnpm-workspace.yaml
+++ b/test/fixtures/package-manager-files/template-storybook/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/test/package-manager-files.test.ts
+++ b/test/package-manager-files.test.ts
@@ -2,11 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { beforeEach, expect, rs, test } from 'rstack/test';
-import { create } from '../src';
+import { copyFolder, create } from '../src';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.join(__dirname, 'fixtures', 'package-manager-files');
 const testDir = path.join(fixturesDir, 'test-temp-output');
+const extraToolDir = path.join(fixturesDir, 'template-storybook');
 
 beforeEach(() => {
   rs.unstubAllEnvs();
@@ -36,6 +37,41 @@ async function createProject(projectDir: string) {
   });
 }
 
+async function createProjectWithExtraTool(projectDir: string) {
+  await create({
+    name: 'test',
+    root: fixturesDir,
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    git: false,
+    builtinTools: [],
+    extraTools: [
+      {
+        value: 'storybook',
+        label: 'Storybook',
+        action: ({ distFolder, skipFiles }) => {
+          copyFolder({
+            from: extraToolDir,
+            to: distFolder,
+            skipFiles,
+            isMergePackageJson: true,
+          });
+        },
+      },
+    ],
+    argv: [
+      'node',
+      'test',
+      '--dir',
+      projectDir,
+      '--template',
+      'vanilla',
+      '--tools',
+      'storybook',
+    ],
+  });
+}
+
 test('should copy pnpm-workspace.yaml for pnpm', async () => {
   const projectDir = path.join(testDir, 'pnpm');
   rs.stubEnv('npm_config_user_agent', 'pnpm/11.20.0');
@@ -52,6 +88,28 @@ test('should skip pnpm-workspace.yaml for other package managers', async () => {
   rs.stubEnv('npm_config_user_agent', 'npm/11.0.0');
 
   await createProject(projectDir);
+
+  expect(fs.existsSync(path.join(projectDir, 'pnpm-workspace.yaml'))).toBe(
+    false,
+  );
+});
+
+test('should copy pnpm-workspace.yaml from an extra tool for pnpm', async () => {
+  const projectDir = path.join(testDir, 'extra-tool-pnpm');
+  rs.stubEnv('npm_config_user_agent', 'pnpm/11.20.0');
+
+  await createProjectWithExtraTool(projectDir);
+
+  expect(
+    fs.readFileSync(path.join(projectDir, 'pnpm-workspace.yaml'), 'utf8'),
+  ).toBe('allowBuilds:\n  esbuild: true\n');
+});
+
+test('should skip pnpm-workspace.yaml from an extra tool for npm', async () => {
+  const projectDir = path.join(testDir, 'extra-tool-npm');
+  rs.stubEnv('npm_config_user_agent', 'npm/11.0.0');
+
+  await createProjectWithExtraTool(projectDir);
 
   expect(fs.existsSync(path.join(projectDir, 'pnpm-workspace.yaml'))).toBe(
     false,


### PR DESCRIPTION
## Summary

Custom extra tool actions currently cannot reuse create-toolkit's resolved package-manager file policy, so local overlays can copy `pnpm-workspace.yaml` into npm, Yarn, or Bun projects.

This PR passes the resolved `skipFiles` list to `ExtraTool.action`, allowing actions to forward the policy to `copyFolder` while remaining backward compatible.