### PR TITLE
chore: use pnpm version for releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "rs lint",
     "prepare": "rs hooks",
     "test": "rs test",
-    "bump": "npx bumpp"
+    "bump": "pnpm version -m \"release: v%s\""
   },
   "devDependencies": {
     "@clack/prompts": "^1.7.0",


### PR DESCRIPTION
## Summary

Use pnpm's built-in version command for release preparation, matching rspack-vue-loader. Replace `npx bumpp` with `pnpm version -m "release: v%s"` to create version commits with the standard release message.