### PR TITLE
fix: use the Biome linter preset instead of the deprecated recommended field

### DIFF
--- a/template-biome/biome.json.template
+++ b/template-biome/biome.json.template
@@ -28,7 +28,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   }
 }


### PR DESCRIPTION
Biome 2.5 deprecates `linter.rules.recommended` in favor of `preset`, so a project scaffolded with Biome reports a deprecation on its first `biome check`. This is the configuration `biome migrate` produces.