### PR TITLE
fix: sort the imports of the React TypeScript Rslint config

### DIFF
--- a/template-rslint/react-ts/rslint.config.ts
+++ b/template-rslint/react-ts/rslint.config.ts
@@ -1,9 +1,9 @@
 import {
   defineConfig,
   js,
-  ts,
-  reactPlugin,
   reactHooksPlugin,
+  reactPlugin,
+  ts,
 } from '@rslint/core';
 
 export default defineConfig([


### PR DESCRIPTION
The named imports in `template-rslint/react-ts/rslint.config.ts` were out of order, so a project scaffolded with Rslint and Biome failed `biome check` (`assist/source/organizeImports`) on its first run. The other three Rslint configs already pass.